### PR TITLE
Stricter definition of blocks to satisfy Xcode 9

### DIFF
--- a/Pod/Classes/AFMInfoBanner.h
+++ b/Pod/Classes/AFMInfoBanner.h
@@ -20,9 +20,9 @@ typedef NS_ENUM(NSUInteger, AFMInfoBannerStyle) {
 @property (nonatomic) AFMInfoBannerStyle style;
 @property (nonatomic) NSString *text;
 
-@property (nonatomic, copy) void (^showCompletionBlock)();
-@property (nonatomic, copy) void (^hideCompletionBlock)();
-@property (nonatomic, copy) void (^tappedBlock)();
+@property (nonatomic, copy) void (^showCompletionBlock)(void);
+@property (nonatomic, copy) void (^hideCompletionBlock)(void);
+@property (nonatomic, copy) void (^tappedBlock)(void);
 
 @property (nonatomic) UIFont *font UI_APPEARANCE_SELECTOR;
 @property (nonatomic) UIColor *errorBackgroundColor UI_APPEARANCE_SELECTOR;
@@ -39,8 +39,8 @@ typedef NS_ENUM(NSUInteger, AFMInfoBannerStyle) {
 
 - (void)show:(BOOL)animated;
 - (void)hide:(BOOL)animated;
-- (void)show:(BOOL)animated withCompletion:(void (^)())completionBlock;
-- (void)hide:(BOOL)animated withCompletion:(void (^)())completionBlock;
+- (void)show:(BOOL)animated withCompletion:(void (^)(void))completionBlock;
+- (void)hide:(BOOL)animated withCompletion:(void (^)(void))completionBlock;
 - (void)showAndHideAfter:(NSTimeInterval)timeout animated:(BOOL)animated;
 
 + (instancetype)showWithText:(NSString *)text

--- a/Pod/Classes/AFMInfoBanner.m
+++ b/Pod/Classes/AFMInfoBanner.m
@@ -267,13 +267,13 @@ static const CGFloat kDefaultHideInterval = 2.0;
     [self layoutIfNeeded];
 }
 
-- (void)show:(BOOL)animated withCompletion:(void (^)())completionBlock
+- (void)show:(BOOL)animated withCompletion:(void (^)(void))completionBlock
 {
     self.showCompletionBlock = completionBlock;
     [self show:animated];
 }
 
-- (void)hide:(BOOL)animated withCompletion:(void (^)())completionBlock
+- (void)hide:(BOOL)animated withCompletion:(void (^)(void))completionBlock
 {
     self.hideCompletionBlock = completionBlock;
     [self hide:animated];


### PR DESCRIPTION
Xcode 9 is stricter than earlier versions when it comes to block definitions. This will suppress the warnings.

More reading here: https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9